### PR TITLE
Support automatic inclusion of webpack chunks in generated HTML

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ KssPlugin.prototype.apply = function (compiler) {
 KssPlugin.prototype.render = function (compilation, callback) {
   var self = this;
   new Promise(function(resolve, reject) {
-    var assets = this._buildAssets(compilation);
+    var assets = self._buildAssets(compilation);
   
     kss(Object.assign({}, self.options, assets), function (error) {
       if (error) throw error;

--- a/index.js
+++ b/index.js
@@ -8,16 +8,21 @@ function KssPlugin(options) {
   if (!options.source) {
     throw 'kss webpack plugin: source is not defined';
   }
-  if(!options.chunks) {
-    throw 'kss webpack plugin: chunks not defined'
-  }
   this.options = options;
 }
 
 KssPlugin.prototype.apply = function (compiler) {
-  compiler.plugin('emit', (compilation, callback) => {
-    this.render(compilation, callback);
-  });
+  if (!options.chunks) {
+    compiler.plugin('done', function() {
+      kss(self.options, function (error) {
+        if (error) throw error;
+      });
+    });
+  } else {
+    compiler.plugin('emit', (compilation, callback) => {
+      this.render(compilation, callback);
+    });
+  }
 };
 
 KssPlugin.prototype.render = function (compilation, callback) {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var kss = require('kss');
+var path = require('path');
 
 function KssPlugin(options) {
   if (!options) {
@@ -7,16 +8,62 @@ function KssPlugin(options) {
   if (!options.source) {
     throw 'kss webpack plugin: source is not defined';
   }
+  if(!options.chunks) {
+    throw 'kss webpack plugin: chunks not defined'
+  }
   this.options = options;
 }
 
 KssPlugin.prototype.apply = function (compiler) {
+  compiler.plugin('emit', (compilation, callback) => {
+    this.render(compilation, callback);
+  });
+};
+
+KssPlugin.prototype.render = function (compilation, callback) {
   var self = this;
-  compiler.plugin('done', function() {
-    kss(self.options, function (error) {
+  new Promise(function(resolve, reject) {
+    var assets = this._buildAssets(compilation);
+  
+    kss(Object.assign({}, self.options, assets), function (error) {
       if (error) throw error;
     });
+    resolve();
+  }).then(() => {
+      callback();
+    }
+  )
+};
+
+KssPlugin.prototype._buildAssets = function (compilation) {
+  const assets = {
+    css: [],
+    js: []
+  };
+
+  this.options.chunks.forEach(function(key) {
+    var pushAsset = function(file) {
+      const ext = path.extname(file);
+
+      if (ext === '.css') {
+          assets.css.push(path.join('/', file))
+      } else if (ext === '.js') {
+          assets.js.push(path.join('/', file));
+      }
+    }   
+
+    const asset = compilation.getStats().toJson().assetsByChunkName[key];
+
+    if(typeof asset === 'string') {
+      pushAsset(asset)
+    } else {
+      asset.forEach((file) => {
+        pushAsset(file)
+      })
+    }
   });
+
+  return assets;
 };
 
 module.exports = KssPlugin;

--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ function KssPlugin(options) {
 }
 
 KssPlugin.prototype.apply = function (compiler) {
-  if (!options.chunks) {
+  var self = this;
+  if (!self.options.chunks) {
     compiler.plugin('done', function() {
       kss(self.options, function (error) {
         if (error) throw error;


### PR DESCRIPTION
This allows the webpack user to define a `chunks` key in the `KssWebpackPlugin` options object, in which the user specifies an array of named "chunks" (JS or CSS) which they want to include in the generated HTML e.g:

```js
new KssWebpackPlugin({
    title: 'My pattern library',
    source: 'src/scss',
    destination: 'dest/styleguide/',
    chunks: ['manifest', 'vendor', 'styles']
})
```

The additions to the code separate the chunks by their output file extension, putting anything ending `.js` into the kss `options.js` config option, and any `.css` into `options.css`
  