### PR TITLE
Improve Webpack 4 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,16 +13,32 @@ function KssPlugin(options) {
 
 KssPlugin.prototype.apply = function (compiler) {
   var self = this;
+
+  var kssCompile = function(compilation) {
+    kss(self.options, function(error) {
+      if (error) throw error;
+    });
+  }
+
+  var kssRender = function(compilation, callback) {
+    this.render(compilation, callback);
+  }
+
   if (!self.options.chunks) {
-    compiler.plugin('done', function() {
-      kss(self.options, function (error) {
-        if (error) throw error;
-      });
-    });
-  } else {
-    compiler.plugin('emit', (compilation, callback) => {
-      this.render(compilation, callback);
-    });
+    if (compiler.hooks) {
+      compiler.hooks.done.tap('KssPlugin', kssCompile);
+    }
+    else {
+      compiler.plugin('done', kssCompile);
+    }
+  }
+  else {
+    if (compiler.hooks) {
+      compiler.hooks.emit.tap('KssPlugin', kssRender);
+    }
+    else {
+      compiler.plugin('emit', kssRender);
+    }
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
   "dependencies": {
     "kss": "^3.0.0 || ^3.0.0-beta.14"
   },
+  "peerDependencies": {
+    "webpack": "3 || 4"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/jonespen/kss-webpack-plugin.git"


### PR DESCRIPTION
Improves compatibility for Webpack 4 and eliminates the Tapable warning mentioned in Issue #7. Followed the example provided by davecranwell-adestra. Very open to feedback!