### PR TITLE
Fixed missing render callback error

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,8 @@ KssPlugin.prototype.apply = function apply(compiler) {
   }
 };
 
-KssPlugin.prototype.render = function render(compilation, callback) {
+KssPlugin.prototype.render = function render(compilation, cb) {
+  const callback = typeof cb === 'function' ? cb : () => {};
   new Promise((resolve) => {
     const assets = this._buildAssets(compilation);
 


### PR DESCRIPTION
The render method might throw a type error because of an undefined callback (callback is not a function). Added check for the render callback.