### PR TITLE
Add option to set assetPath with chunks-option

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,9 +69,9 @@ KssPlugin.prototype._buildAssets = function (compilation) {
       const ext = path.extname(file);
 
       if (ext === '.css') {
-          assets.css.push(path.join('/', file))
+        assets.css.push(path.join('/', path.join(this.options.assetPath, file)))
       } else if (ext === '.js') {
-          assets.js.push(path.join('/', file));
+        assets.js.push(path.join('/', path.join(this.options.assetPath, file)));
       }
     }
 


### PR DESCRIPTION
Since asset loading was hardcoded to always be included from the respective project root, I added an option to allow the path to the assets to be set in the KssPlugin config object inside `webpack.config.js`

Like so: 
```js 
const KssConfig = {
  source: './src/scss',
  chunks: ['app', 'some', 'chunk'],
  assetPath: 'path/to/your/compiled/assets/',
};
```
